### PR TITLE
Role switching on admin page works

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
       "comma-dangle": 0,
       "import/no-extraneous-dependencies": 1,
       "no-param-reassign": 1,
-      "quotes": 1
+      "quotes": 1,
+      "react/require-default-props": 0
     }
 }

--- a/app/components/Admin.jsx
+++ b/app/components/Admin.jsx
@@ -9,9 +9,10 @@ class Admin extends Component {
   }
 
   render() {
-    // const users = _.sortBy(this.props.users, 'lastName');
-
+    // Users array is sorted first by type (admins first), then last and first name
+    const users = _.sortBy(this.props.users, ['type', 'lastName', 'firstName']);
     console.log('got users from store:', users);
+
     return (
       <div>
         <div className="page-header col-xs-12">

--- a/app/components/Admin.jsx
+++ b/app/components/Admin.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import _ from 'lodash';
 import AdminModule from './AdminModule';
 
 class Admin extends Component {
@@ -8,7 +9,8 @@ class Admin extends Component {
   }
 
   render() {
-    const { users } = this.props;
+    // const users = _.sortBy(this.props.users, 'lastName');
+
     console.log('got users from store:', users);
     return (
       <div>
@@ -24,16 +26,12 @@ class Admin extends Component {
 
 const mapStateToProps = (state) => {
   const { users } = state;
-  console.log('heres users', users);
+  console.log('here are your users:', users);
   return { users };
 };
 
+Admin.propTypes = {
+  users: PropTypes.arrayOf(PropTypes.object)
+};
+
 export default connect(mapStateToProps)(Admin);
-
-
-// Admin.propTypes = {
-//   users: PropTypes.array,
-// };
-    // {
-    //   props.users.map((user, i) => <AdminModule key={i} user={user} />)
-    // }

--- a/app/components/AdminModule.jsx
+++ b/app/components/AdminModule.jsx
@@ -1,9 +1,11 @@
-import React, { Component } from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 
+import { switchRole } from '../reducers/users';
+
 const AdminModule = (props) => {
-  const { fullName, email, billingAddress } = props.user;
+  const { fullName, email, billingAddress, type } = props.user;
 
   return (
     <div className="row col-xs-12">
@@ -23,17 +25,11 @@ const AdminModule = (props) => {
 
       <div className="col-xs-12 col-sm-4">
         <div>
-          <input type="radio" checked />
-          <label>
-            &emsp;Admin
-          </label>
-        </div>
-
-        <div>
-          <input type="radio" />
-          <label>
-            &emsp;Not Admin
-          </label>
+          <strong>Role</strong><br />
+          <select name="role" value={type} onChange={evt => props.toggleRole(evt)}>
+            <option value="admin">Admin</option>
+            <option value="member">Member</option>
+          </select>
         </div>
       </div>
     </div>
@@ -45,4 +41,23 @@ const mapStateToProps = (state, ownProps) => {
   return { user };
 };
 
-export default connect(mapStateToProps)(AdminModule);
+const mapDispatchToProps = (dispatch, ownProps) => {
+  const { user } = ownProps;
+  return {
+    toggleRole: (evt) => {
+      dispatch(switchRole(user.id, evt.target.value));
+    }
+  };
+};
+
+AdminModule.propTypes = {
+  user: PropTypes.shape({
+    fullName: PropTypes.string,
+    email: PropTypes.string,
+    billingAddress: PropTypes.object,
+    type: PropTypes.string,
+  }),
+  toggleRole: PropTypes.func,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(AdminModule);

--- a/app/reducers/users.js
+++ b/app/reducers/users.js
@@ -17,6 +17,19 @@ export const fetchUsers = () =>
       });
   };
 
+const SWITCH_ROLE = 'SWITCH_ROLE';
+export const switchRole = (userId, newRole) =>
+  (dispatch) => {
+    axios.put(`/api/users/${userId}`, { type: newRole })
+      .then(res => res.data)
+      .then((payload) => {
+        console.log('payload:', payload);
+      })
+      .catch((err) => {
+        console.error('Error updating user role reducers/users.jsx:', err);
+      });
+  };
+
 // Reducer
 export default (state = [], action) => {
   let newState;

--- a/app/reducers/users.js
+++ b/app/reducers/users.js
@@ -17,13 +17,13 @@ export const fetchUsers = () =>
       });
   };
 
-const SWITCH_ROLE = 'SWITCH_ROLE';
 export const switchRole = (userId, newRole) =>
   (dispatch) => {
     axios.put(`/api/users/${userId}`, { type: newRole })
       .then(res => res.data)
       .then((payload) => {
         console.log('payload:', payload);
+        dispatch(fetchUsers());
       })
       .catch((err) => {
         console.error('Error updating user role reducers/users.jsx:', err);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "cookie-session": "^2.0.0-alpha.1",
     "enzyme": "^2.5.1",
     "express": "^4.14.0",
+    "lodash": "^4.17.4",
     "passport": "^0.3.2",
     "passport-facebook": "^2.1.1",
     "passport-github2": "^0.1.10",

--- a/server/users.js
+++ b/server/users.js
@@ -55,6 +55,16 @@ module.exports = require('express').Router()
     .then(user => res.json(user))
     .catch(next))
 
+  // Update one user by ID
+  // TODO: ADD AS SECOND ARGUMENT mustBeLoggedInAsAdmin
+  .put('/:userId', (req, res, next) =>
+    req.user
+    .then(user => user.update(req.body))
+    .then(() => {
+      res.status(201).send();
+    })
+    .catch(next))
+
   // Get all orders of one user
   .get('/:userId/orders', (req, res, next) =>
     req.user


### PR DESCRIPTION
Admins are listed first, then members (and alphabetically within those categories). When a user's role is switched, the list rerenders.